### PR TITLE
修改统一身份认证系统的url地址，加上?参数

### DIFF
--- a/grade.py
+++ b/grade.py
@@ -8,7 +8,7 @@ from config import username,password,sleep_time
 import time
 import os
 import pickle
-url1='https://passport.ustc.edu.cn/login'
+url1='https://passport.ustc.edu.cn/login?service=https://jw.ustc.edu.cn/ucas-sso/login'
 url2='https://jw.ustc.edu.cn/ucas-sso/login'
 url3='https://jw.ustc.edu.cn/for-std/grade/sheet/getSemesters'
 url4='https://jw.ustc.edu.cn/for-std/grade/sheet/getGradeList?trainTypeId=1&semesterIds='


### PR DESCRIPTION
今天使用此脚本抓取成绩的时候一直无法登录，显示 timeout。**修改了 url1 的值之后就可以正常登录了**。

我前两天写了一个 GitHub Action 在云端自动抓取成绩。之前一段时间运行没有问题，但是今天下午开始就会一直 timeout 失败。本地运行也是失败。把 url1 的值修改之后，证实可以正常登录。

下面是GitHub Actions的运行记录，省略了下面数十条失败记录。可以看到，我改完url之后，抓取立刻就成功了。原网页在 https://github.com/WuTianming/ustc-new-grade-actions/actions
![这是GitHub Actions的运行记录，省略了下面数十条失败记录](https://user-images.githubusercontent.com/16624684/106280196-8d3b3f80-6278-11eb-8920-e7d3fab2c2c5.png)

（这个修改参考了 [yusanshi/USTC-grade-notification](https://github.com/yusanshi/USTC-grade-notification) 的写法。）